### PR TITLE
루틴 관련 API에서 order를 사용자에게 직접 입력받지 않도록 변경

### DIFF
--- a/app/api/endpoints/routine.py
+++ b/app/api/endpoints/routine.py
@@ -7,14 +7,13 @@ from app.api.strings import (
 )
 from app.core.auth import get_current_user
 from app.database.db import get_db
-from app.models.models import Routine, RoutineElement, User
+from app.models.models import Routine, User
 from app.repositories import get_routine_repository
 from app.repositories.routine_repository import RoutineRepository
 from app.schemas.response import Response
 from app.schemas.routine import (
     RoutineCreateInput,
     RoutineDetail,
-    RoutineItem,
     RoutineUpdateInput,
 )
 
@@ -33,54 +32,13 @@ router = APIRouter(
 def create_routine(
     data: RoutineCreateInput,
     db: Session = Depends(get_db),
-    user=Depends(get_current_user),
+    repository: RoutineRepository = Depends(get_routine_repository),
+    user: User = Depends(get_current_user),
 ):
-    repeat_days = "".join([str(day) for day in data.repeat_days])
-
-    routine = Routine(
-        title=data.title,
-        start_time_minutes=data.start_time_minutes,
-        repeat_days=repeat_days,
-        user_id=user.id,
-    )
-
-    commit_and_catch_exception(db, lambda: db.add(routine))
-
-    routine_elements = [
-        RoutineElement(
-            user_id=user.id,
-            title=item.title,
-            order=item.order,
-            duration_minutes=item.duration_minutes,
-            routine_id=routine.id,
-        )
-        for item in data.routine_elements
-    ]
-
-    commit_and_catch_exception(db, lambda: db.add_all(routine_elements))
+    routine = repository.create_routine(data)
 
     return Response(
-        data=RoutineDetail(
-            id=routine.id,
-            title=routine.title,
-            start_time_minutes=routine.start_time_minutes,
-            repeat_days=data.repeat_days,
-            created_at=routine.created_at,
-            updated_at=routine.updated_at,
-            deleted_at=None,
-            routine_elements=[
-                RoutineItem(
-                    id=item.id,
-                    title=item.title,
-                    order=item.order,
-                    duration_minutes=item.duration_minutes,
-                    created_at=item.created_at,
-                    updated_at=item.updated_at,
-                    completed=False,
-                )
-                for item in routine_elements
-            ],
-        ),
+        data=routine,
         message="Routine created successfully",
         status_code=status.HTTP_201_CREATED,
     )
@@ -114,26 +72,7 @@ def get_routine(
         )
 
     response = Response(
-        data=RoutineDetail(
-            id=routine.id,
-            created_at=routine.created_at,
-            updated_at=routine.updated_at,
-            title=routine.title,
-            start_time_minutes=routine.start_time_minutes,
-            repeat_days=routine.repeat_days_to_list(),
-            routine_elements=[
-                RoutineItem(
-                    id=item.id,
-                    title=item.title,
-                    order=item.order,
-                    duration_minutes=item.duration_minutes,
-                    created_at=item.created_at,
-                    updated_at=item.updated_at,
-                    completed=False,
-                )
-                for item in routine.routine_elements
-            ],
-        ),
+        data=RoutineDetail.from_routine(routine, routine.routine_elements),
         message="Routine retrieved successfully",
         status_code=status.HTTP_200_OK,
     )
@@ -178,15 +117,6 @@ def delete_routine(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=SERVER_UNTRACKED_ERROR,
         )
-
-
-def commit_and_catch_exception(db: Session, db_action: callable):
-    try:
-        db_action()
-        db.commit()
-    except Exception as e:
-        db.rollback()
-        raise e
 
 
 @router.put(

--- a/app/dao/routine_dao.py
+++ b/app/dao/routine_dao.py
@@ -47,3 +47,26 @@ class RoutineDAO(ProtectedBaseDAO):
             self.db.rollback()
 
             raise Exception("Failed to update routine")
+
+    def create_routine(
+        self,
+        title: str,
+        start_time_minutes: int,
+        repeat_days: List[int],
+    ) -> Routine:
+        routine = Routine(
+            title=title,
+            start_time_minutes=start_time_minutes,
+            repeat_days=Routine.repeat_days_to_string(repeat_days),
+            user_id=self.user_id,
+        )
+
+        try:
+            self.db.add(routine)
+            self.db.commit()
+
+            return routine
+        except SQLAlchemyError:
+            self.db.rollback()
+
+            raise Exception("Failed to add routine")

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -144,7 +144,8 @@ class Routine(Base):
     def repeat_days_to_list(self):
         return [int(day) for day in self.repeat_days]
 
-    def repeat_days_to_string(self, repeat_days):
+    @staticmethod
+    def repeat_days_to_string(repeat_days):
         return "".join([str(day) for day in repeat_days])
 
 

--- a/app/repositories/routine_repository.py
+++ b/app/repositories/routine_repository.py
@@ -3,7 +3,11 @@ from sqlalchemy.orm import Session
 from app.dao.routine_dao import RoutineDAO
 from app.dao.routine_element_dao import RoutineElementDAO
 from app.models.models import Routine
-from app.schemas.routine import RoutineUpdateInput
+from app.schemas.routine import (
+    RoutineCreateInput,
+    RoutineDetail,
+    RoutineUpdateInput,
+)
 
 from .base import ProtectedBaseRepository
 
@@ -30,3 +34,19 @@ class RoutineRepository(ProtectedBaseRepository):
         )
 
         return updated_routine
+
+    def create_routine(self, routine: RoutineCreateInput) -> RoutineDetail:
+        new_routine = self.routine_dao.create_routine(
+            title=routine.title,
+            start_time_minutes=routine.start_time_minutes,
+            repeat_days=routine.repeat_days,
+        )
+
+        routine_elements = self.routine_element_dao.create_routine_elements(
+            routine_id=new_routine.id,
+            routine_elements=routine.routine_elements,
+        )
+
+        return RoutineDetail.from_routine(
+            routine=new_routine, routine_elements=routine_elements
+        )

--- a/app/schemas/routine.py
+++ b/app/schemas/routine.py
@@ -7,7 +7,6 @@ from app.models.models import Routine, RoutineElement
 
 class RoutineItemBase(BaseModel):
     title: str
-    order: int
     duration_minutes: int
 
 
@@ -58,7 +57,6 @@ class RoutineDetail(RoutineBase):
                 RoutineItem(
                     id=item.id,
                     title=item.title,
-                    order=item.order,
                     duration_minutes=item.duration_minutes,
                     created_at=item.created_at,
                     updated_at=item.updated_at,

--- a/tests/api/endpoints/protected/routine/conftest.py
+++ b/tests/api/endpoints/protected/routine/conftest.py
@@ -18,9 +18,9 @@ def routine_data() -> RoutineCreateInput:
         start_time_minutes=480,
         repeat_days=[1, 2, 3, 4, 5],
         routine_elements=[
-            RoutineItemUpdate(title="아침 물 마시기", duration_minutes=5, order=1),
-            RoutineItemUpdate(title="아침 운동하기", duration_minutes=30, order=2),
-            RoutineItemUpdate(title="아침 식사하기", duration_minutes=15, order=3),
+            RoutineItemUpdate(title="아침 물 마시기", duration_minutes=5),
+            RoutineItemUpdate(title="아침 운동하기", duration_minutes=30),
+            RoutineItemUpdate(title="아침 식사하기", duration_minutes=15),
         ],
     )
 
@@ -48,18 +48,10 @@ def update_routine_only_elements_data() -> RoutineUpdateInput:
     return RoutineUpdateInput(
         routine_id=1,
         routine_elements=[
-            RoutineItemUpdate(
-                id=1, title="아침 물 마시기 업데이트", order=1, duration_minutes=5
-            ),
-            RoutineItemUpdate(
-                id=2, title="아침 운동하기 업데이트", order=2, duration_minutes=30
-            ),
-            RoutineItemUpdate(
-                title="추가된 루틴 아이템 1", duration_minutes=10, order=3
-            ),
-            RoutineItemUpdate(
-                title="추가된 루틴 아이템 2", duration_minutes=10, order=4
-            ),
+            RoutineItemUpdate(id=1, title="아침 물 마시기 업데이트", duration_minutes=5),
+            RoutineItemUpdate(id=2, title="아침 운동하기 업데이트", duration_minutes=30),
+            RoutineItemUpdate(title="추가된 루틴 아이템 1", duration_minutes=10),
+            RoutineItemUpdate(title="추가된 루틴 아이템 2", duration_minutes=10),
         ],
     )
 
@@ -72,8 +64,8 @@ def update_routine_all_data() -> RoutineUpdateInput:
         start_time_minutes=120,
         repeat_days=[1, 2, 3],
         routine_elements=[
-            RoutineItemUpdate(title="점심 물 마시기", duration_minutes=5, order=1),
-            RoutineItemUpdate(title="점심 운동하기", duration_minutes=30, order=2),
+            RoutineItemUpdate(title="점심 물 마시기", duration_minutes=5),
+            RoutineItemUpdate(title="점심 운동하기", duration_minutes=30),
         ],
     )
 
@@ -98,11 +90,11 @@ def add_routine(
         RoutineElement(
             user_id=add_user.id,
             title=item.title,
-            order=item.order,
+            order=index,
             duration_minutes=item.duration_minutes,
             routine_id=test_routine.id,
         )
-        for item in routine_data.routine_elements
+        for index, item in enumerate(routine_data.routine_elements)
     ]
 
     session.add_all(routine_elements)
@@ -119,7 +111,6 @@ def add_routine(
             RoutineItem(
                 id=item.id,
                 title=item.title,
-                order=item.order,
                 duration_minutes=item.duration_minutes,
                 created_at=item.created_at,
                 updated_at=item.updated_at,

--- a/tests/api/endpoints/protected/routine/test_routine.py
+++ b/tests/api/endpoints/protected/routine/test_routine.py
@@ -38,7 +38,6 @@ def test_create_routine(
     ):
         assert routine_item.title == todo_item.title
         assert routine_item.duration_minutes == todo_item.duration_minutes
-        assert routine_item.order == todo_item.order
 
     assert session.query(Routine).count() == 1
     assert session.query(RoutineElement).count() == len(
@@ -172,16 +171,8 @@ def test_update_routine_only_elements_data(
         == update_routine_only_elements_data.routine_elements[2].title
     )
     assert (
-        response_data.routine_elements[2].order
-        == update_routine_only_elements_data.routine_elements[2].order
-    )
-    assert (
         response_data.routine_elements[3].title
         == update_routine_only_elements_data.routine_elements[3].title
-    )
-    assert (
-        response_data.routine_elements[3].order
-        == update_routine_only_elements_data.routine_elements[3].order
     )
 
 
@@ -216,7 +207,6 @@ def test_update_routine_only_routine_data(
     ):
         assert routine_item.title == todo_item.title
         assert routine_item.duration_minutes == todo_item.duration_minutes
-        assert routine_item.order == todo_item.order
 
 
 def test_update_routine_empty_routine_elements(


### PR DESCRIPTION
Resolve #47 
# 작업 내용
- 루틴 관련 API 전체에서 사용자에게 직접적으로 order를 직접 입력받지 않도록 변경했습니다.
- 이제 자동으로 order를 넣어줄겁니다. 사용자가 실수할 일이 적도록...