### PR TITLE
기존 API들 DAO & Repo 방식으로 마이그레이션

### DIFF
--- a/app/api/endpoints/auth.py
+++ b/app/api/endpoints/auth.py
@@ -1,23 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
-from werkzeug.security import generate_password_hash, check_password_hash
+from fastapi import APIRouter, Depends, status
 
-from app.core.auth import (
-    decode_token,
-    generate_access_token,
-    generate_refresh_token,
-)
-from app.database.db import get_db
-from app.models.models import User
+from app.dao import get_auth_dao
+from app.dao.auth_dao import AuthDAO
+from app.database.db import tx_manager
 from app.schemas.response import Response
-from app.api.strings import (
-    EMAIL_ALREADY_EXISTS_ERROR,
-    INVALID_LOGIN_ERROR,
-    REQUIRE_REFRESH_TOKEN_ERROR,
-    SERVER_UNTRACKED_ERROR,
-    USER_NOT_AUTHENTICATED_ERROR,
-    USERNAME_ALREADY_EXISTS_ERROR,
-)
 from app.schemas.auth import (
     LoginInput,
     LoginOutput,
@@ -30,99 +16,44 @@ from app.schemas.auth import (
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-def user_exists(db: Session, username: str, email: str):
-    if db.query(User).filter_by(username=username).first():
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=USERNAME_ALREADY_EXISTS_ERROR,
-        )
-    if db.query(User).filter_by(email=email).first():
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=EMAIL_ALREADY_EXISTS_ERROR,
-        )
-
-
 @router.post("/signup", response_model=Response[SignupOutput], status_code=201)
-async def signup(data: SignupInput, db: Session = Depends(get_db)):
-    password_hash = generate_password_hash(data.password)
+async def signup(
+    data: SignupInput,
+    auth_dao: AuthDAO = Depends(get_auth_dao),
+    tx_manager: None = Depends(tx_manager),
+):
+    with tx_manager:
+        user = auth_dao.sign_up(data)
 
-    user = User(
-        username=data.username,
-        password=password_hash,
-        email=data.email,
-        grade=data.grade,
-        profile_image=data.profile_image,
-        nickname=data.nickname or data.username,
+    return Response(
+        message="Signup success",
+        status_code=status.HTTP_201_CREATED,
+        data=SignupOutput.from_orm(user),
     )
-
-    user_exists(db, user.username, user.email)
-
-    try:
-        db.add(user)
-        db.commit()
-
-        return Response(
-            message="Signup success",
-            status_code=status.HTTP_201_CREATED,
-            data=SignupOutput.from_orm(user),
-        )
-    except Exception:
-        db.rollback()
-
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=SERVER_UNTRACKED_ERROR,
-        )
 
 
 @router.post("/login", response_model=Response[LoginOutput], status_code=200)
-async def login(data: LoginInput, db: Session = Depends(get_db)):
-    user = db.query(User).filter_by(username=data.username).first()
-
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=INVALID_LOGIN_ERROR,
-        )
-
-    if not check_password_hash(user.password, data.password):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=INVALID_LOGIN_ERROR,
-        )
-
-    access_token = generate_access_token(user.username)
-    refresh_token = generate_refresh_token(user.username)
+async def login(
+    data: LoginInput,
+    auth_dao: AuthDAO = Depends(get_auth_dao),
+    tx_manager: None = Depends(tx_manager),
+):
+    with tx_manager:
+        login_output = auth_dao.login(data.username, data.password)
 
     return Response(
         status_code=status.HTTP_200_OK,
-        data=LoginOutput(
-            access_token=access_token, refresh_token=refresh_token
-        ),
+        data=login_output,
     )
 
 
 @router.post(
     "/refresh", response_model=Response[RefreshOutput], status_code=200
 )
-async def refresh(data: RefreshInput, db: Session = Depends(get_db)):
-    if not data.refresh_token:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=REQUIRE_REFRESH_TOKEN_ERROR,
-        )
-
-    username = decode_token(data.refresh_token)
-
-    if not username:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=USER_NOT_AUTHENTICATED_ERROR,
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    access_token = generate_access_token(username)
+async def refresh(
+    data: RefreshInput, auth_dao: AuthDAO = Depends(get_auth_dao)
+):
+    access_token = auth_dao.refresh(data.refresh_token)
 
     return Response(
         status_code=status.HTTP_200_OK,

--- a/app/api/endpoints/routine.py
+++ b/app/api/endpoints/routine.py
@@ -1,10 +1,9 @@
+from contextlib import contextmanager
 from fastapi import APIRouter, Depends, status
-from sqlalchemy.orm import Session
 from app.core.auth import get_current_user
 from app.dao import get_routine_dao
 from app.dao.routine_dao import RoutineDAO
-from app.database.db import get_db
-from app.models.models import User
+from app.database.db import tx_manager
 from app.repositories import get_routine_repository
 from app.repositories.routine_repository import RoutineRepository
 from app.schemas.response import Response
@@ -28,11 +27,11 @@ router = APIRouter(
 )
 def create_routine(
     data: RoutineCreateInput,
-    db: Session = Depends(get_db),
     repository: RoutineRepository = Depends(get_routine_repository),
-    user: User = Depends(get_current_user),
+    tx_manager: contextmanager = Depends(tx_manager),
 ):
-    routine = repository.create_routine(data)
+    with tx_manager:
+        routine = repository.create_routine(data)
 
     return Response(
         data=routine,
@@ -46,12 +45,7 @@ def create_routine(
     response_model=Response[RoutineDetail],
     status_code=status.HTTP_200_OK,
 )
-def get_routine(
-    routine_id: int,
-    db: Session = Depends(get_db),
-    user: User = Depends(get_current_user),
-    dao: RoutineDAO = Depends(get_routine_dao),
-):
+def get_routine(routine_id: int, dao: RoutineDAO = Depends(get_routine_dao)):
     routine = dao.get_routine_with_elements_by_id(routine_id)
 
     response = Response(
@@ -70,11 +64,11 @@ def get_routine(
 )
 def delete_routine(
     routine_id: int,
-    db: Session = Depends(get_db),
-    user: User = Depends(get_current_user),
     dao: RoutineDAO = Depends(get_routine_dao),
+    tx_manager: contextmanager = Depends(tx_manager),
 ):
-    dao.soft_delete_routine(routine_id)
+    with tx_manager:
+        dao.soft_delete_routine(routine_id)
 
     return None
 
@@ -88,9 +82,12 @@ def update_routine(
     routine_id: int,
     data: RoutineUpdateInput,
     repository: RoutineRepository = Depends(get_routine_repository),
-    user: User = Depends(get_current_user),
+    tx_manager: contextmanager = Depends(tx_manager),
 ):
-    routine = repository.update_routine(data)
+    with tx_manager:
+        routine = repository.update_routine(
+            routine_id=routine_id, routine=data
+        )
 
     return Response(
         data=RoutineDetail.from_routine(routine, routine.routine_elements),

--- a/app/api/endpoints/todo.py
+++ b/app/api/endpoints/todo.py
@@ -39,11 +39,13 @@ def get_todo(
 def create_todo(
     data: TodoBase,
     dao: TodoDAO = Depends(get_todo_dao),
+    tx_manager: contextmanager = Depends(tx_manager),
 ):
-    todo = dao.create_todo(
-        title=data.title,
-        content=data.content,
-    )
+    with tx_manager:
+        todo = dao.create_todo(
+            title=data.title,
+            content=data.content,
+        )
 
     return Response(
         status_code=status.HTTP_201_CREATED, data=TodoDetail.from_orm(todo)

--- a/app/api/endpoints/todo.py
+++ b/app/api/endpoints/todo.py
@@ -1,10 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
-from app.api.strings import SERVER_UNTRACKED_ERROR, TODO_DOES_NOT_EXIST_ERROR
+from contextlib import contextmanager
+from fastapi import APIRouter, Depends, status
 
 from app.core.auth import get_current_user
-from app.database.db import get_db
-from app.models.models import Todo, User
+from app.dao import get_todo_dao
+from app.dao.todo_dao import TodoDAO
+from app.database.db import tx_manager
 from app.schemas.response import Response
 from app.schemas.todo import TodoBase, TodoDetail
 
@@ -22,20 +22,9 @@ router = APIRouter(
 )
 def get_todo(
     todo_id: int,
-    db: Session = Depends(get_db),
-    user: User = Depends(get_current_user),
+    dao: TodoDAO = Depends(get_todo_dao),
 ):
-    todo = (
-        db.query(Todo)
-        .filter(Todo.id == todo_id, Todo.user_id == user.id)
-        .first()
-    )
-
-    if not todo:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=TODO_DOES_NOT_EXIST_ERROR,
-        )
+    todo = dao.get_todo_by_id(todo_id=todo_id)
 
     return Response(
         status_code=status.HTTP_200_OK, data=TodoDetail.from_orm(todo)
@@ -49,29 +38,16 @@ def get_todo(
 )
 def create_todo(
     data: TodoBase,
-    db: Session = Depends(get_db),
-    user=Depends(get_current_user),
+    dao: TodoDAO = Depends(get_todo_dao),
 ):
-    todo = Todo(
+    todo = dao.create_todo(
         title=data.title,
         content=data.content,
-        user_id=user.id,
     )
 
-    try:
-        db.add(todo)
-        db.commit()
-
-        return Response(
-            status_code=status.HTTP_201_CREATED, data=TodoDetail.from_orm(todo)
-        )
-
-    except Exception:
-        db.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=SERVER_UNTRACKED_ERROR,
-        )
+    return Response(
+        status_code=status.HTTP_201_CREATED, data=TodoDetail.from_orm(todo)
+    )
 
 
 @router.put(
@@ -82,37 +58,19 @@ def create_todo(
 def update_todo(
     todo_id: int,
     data: TodoBase,
-    db: Session = Depends(get_db),
-    user=Depends(get_current_user),
+    todo_dao: TodoDAO = Depends(get_todo_dao),
+    tx_manager: contextmanager = Depends(tx_manager),
 ):
-    todo = (
-        db.query(Todo)
-        .filter(Todo.id == todo_id)
-        .filter(Todo.user_id == user.id)
-        .first()
+    with tx_manager:
+        todo = todo_dao.update_todo(
+            todo_id=todo_id,
+            title=data.title,
+            content=data.content,
+        )
+
+    return Response(
+        status_code=status.HTTP_200_OK, data=TodoDetail.from_orm(todo)
     )
-
-    if not todo:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=TODO_DOES_NOT_EXIST_ERROR,
-        )
-
-    todo.title = data.title
-    todo.content = data.content
-
-    try:
-        db.commit()
-
-        return Response(
-            status_code=status.HTTP_200_OK, data=TodoDetail.from_orm(todo)
-        )
-    except Exception:
-        db.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=SERVER_UNTRACKED_ERROR,
-        )
 
 
 @router.delete(
@@ -122,30 +80,12 @@ def update_todo(
 )
 def delete_todo(
     todo_id: int,
-    db: Session = Depends(get_db),
-    user=Depends(get_current_user),
+    todo_dao: TodoDAO = Depends(get_todo_dao),
+    tx_manager: contextmanager = Depends(tx_manager),
 ):
-    todo = (
-        db.query(Todo)
-        .filter(Todo.id == todo_id)
-        .filter(Todo.user_id == user.id)
-        .first()
-    )
-
-    if not todo:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=TODO_DOES_NOT_EXIST_ERROR,
+    with tx_manager:
+        todo_dao.delete_todo(
+            todo_id=todo_id,
         )
 
-    try:
-        db.delete(todo)
-        db.commit()
-
-        return None
-    except Exception:
-        db.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=SERVER_UNTRACKED_ERROR,
-        )
+    return None

--- a/app/dao/__init__.py
+++ b/app/dao/__init__.py
@@ -3,18 +3,40 @@ from sqlalchemy.orm import Session
 from app.core.auth import get_current_user
 
 from app.database.db import get_db
-
+from app.models.models import User
 from .routine_dao import RoutineDAO
 from .routine_element_dao import RoutineElementDAO
+from .todo_dao import TodoDAO
+from .auth_dao import AuthDAO
+from .user_dao import UserDAO
 
 
 def get_routine_dao(
-    db: Session = Depends(get_db), user: int = Depends(get_current_user)
-):
-    return RoutineDAO(db=db, user_id=user.id)
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> RoutineDAO:
+    return RoutineDAO(db=db, user=user)
 
 
 def get_routine_item_dao(
-    db: Session = Depends(get_db), user: int = Depends(get_current_user)
-):
-    return RoutineElementDAO(db=db, user_id=user.id)
+    db: Session = Depends(get_db), user: User = Depends(get_current_user)
+) -> RoutineElementDAO:
+    return RoutineElementDAO(db=db, user=user)
+
+
+def get_todo_dao(
+    db: Session = Depends(get_db), user: User = Depends(get_current_user)
+) -> TodoDAO:
+    return TodoDAO(db=db, user=user)
+
+
+def get_auth_dao(
+    session: Session = Depends(get_db),
+) -> AuthDAO:
+    return AuthDAO(db=session)
+
+
+def get_user_dao(
+    session: Session = Depends(get_db), user: User = Depends(get_current_user)
+) -> UserDAO:
+    return UserDAO(db=session, user=user)

--- a/app/dao/auth_dao.py
+++ b/app/dao/auth_dao.py
@@ -1,0 +1,95 @@
+from fastapi import HTTPException, status
+from werkzeug.security import generate_password_hash, check_password_hash
+from app.api.strings import (
+    EMAIL_ALREADY_EXISTS_ERROR,
+    INVALID_LOGIN_ERROR,
+    REQUIRE_REFRESH_TOKEN_ERROR,
+    USER_NOT_AUTHENTICATED_ERROR,
+    USERNAME_ALREADY_EXISTS_ERROR,
+)
+from app.core.auth import (
+    decode_token,
+    generate_access_token,
+    generate_refresh_token,
+)
+
+from app.models.models import User
+from app.schemas.auth import LoginOutput, SignupInput
+
+from .base import BaseDAO
+
+
+class AuthDAO(BaseDAO):
+    def check_existing_email(self, email: str) -> bool:
+        return self.db.query(User).filter_by(email=email).first() is not None
+
+    def check_existing_username(self, username: str) -> bool:
+        return (
+            self.db.query(User).filter_by(username=username).first()
+            is not None
+        )
+
+    def sign_up(self, data: SignupInput) -> User:
+        password_hash = generate_password_hash(data.password)
+
+        user = User(
+            username=data.username,
+            password=password_hash,
+            email=data.email,
+            grade=data.grade,
+            profile_image=data.profile_image,
+            nickname=data.nickname or data.username,
+        )
+
+        if self.check_existing_username(user.username):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=USERNAME_ALREADY_EXISTS_ERROR,
+            )
+
+        if self.check_existing_email(user.email):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=EMAIL_ALREADY_EXISTS_ERROR,
+            )
+
+        self.db.add(user)
+
+        return user
+
+    def login(self, username: str, password: str) -> LoginOutput:
+        user = self.db.query(User).filter_by(username=username).first()
+        # SELECT * FROM user WHERE username = :username
+
+        if not user or not check_password_hash(user.password, password):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=INVALID_LOGIN_ERROR,
+            )
+
+        access_token = generate_access_token(user.username)
+        refresh_token = generate_refresh_token(user.username)
+
+        return LoginOutput(
+            access_token=access_token, refresh_token=refresh_token
+        )
+
+    def refresh(self, refresh_token: str) -> str:
+        if not refresh_token:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=REQUIRE_REFRESH_TOKEN_ERROR,
+            )
+
+        username = decode_token(refresh_token)
+
+        if not username:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=USER_NOT_AUTHENTICATED_ERROR,
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        access_token = generate_access_token(username)
+
+        return access_token

--- a/app/dao/base.py
+++ b/app/dao/base.py
@@ -1,5 +1,7 @@
 from sqlalchemy.orm import Session
 
+from app.models.models import User
+
 
 class BaseDAO:
     def __init__(self, db: Session):
@@ -7,7 +9,8 @@ class BaseDAO:
 
 
 class ProtectedBaseDAO(BaseDAO):
-    def __init__(self, db: Session, user_id: int):
+    def __init__(self, db: Session, user: User):
         super().__init__(db)
 
-        self.user_id = user_id
+        self.user_id = user.id
+        self.username = user.username

--- a/app/dao/routine_dao.py
+++ b/app/dao/routine_dao.py
@@ -5,7 +5,6 @@ from sqlalchemy.orm import joinedload
 from app.api.strings import ROUTINE_DOES_NOT_EXIST_ERROR
 from app.dao.base import ProtectedBaseDAO
 from app.models.models import Routine
-from sqlalchemy.exc import SQLAlchemyError
 
 
 class RoutineDAO(ProtectedBaseDAO):
@@ -48,7 +47,7 @@ class RoutineDAO(ProtectedBaseDAO):
 
         return routine
 
-    def _update_routine(
+    def update_routine(
         self,
         routine_id: int,
         title: str | None,
@@ -57,23 +56,17 @@ class RoutineDAO(ProtectedBaseDAO):
     ) -> Routine:
         routine = self.get_routine_by_id(routine_id)
 
-        try:
-            routine.title = title or routine.title
-            routine.start_time_minutes = (
-                start_time_minutes or routine.start_time_minutes
-            )
-            routine.repeat_days = (
-                repeat_days and routine.repeat_days_to_string(repeat_days)
-            ) or routine.repeat_days
-
-            self.db.flush()
-        except SQLAlchemyError:
-            self.db.rollback()
-            raise Exception("Failed to update routine")
+        routine.title = title or routine.title
+        routine.start_time_minutes = (
+            start_time_minutes or routine.start_time_minutes
+        )
+        routine.repeat_days = (
+            repeat_days and routine.repeat_days_to_string(repeat_days)
+        ) or routine.repeat_days
 
         return routine
 
-    def _create_routine(
+    def create_routine(
         self,
         title: str,
         start_time_minutes: int,
@@ -86,12 +79,7 @@ class RoutineDAO(ProtectedBaseDAO):
             user_id=self.user_id,
         )
 
-        try:
-            self.db.add(routine)
-            self.db.flush()
-        except SQLAlchemyError:
-            self.db.rollback()
-            raise Exception("Failed to create routine")
+        self.db.add(routine)
 
         return routine
 
@@ -101,11 +89,4 @@ class RoutineDAO(ProtectedBaseDAO):
     ) -> None:
         routine = self.get_routine_by_id(routine_id)
 
-        try:
-            routine.deleted_at = datetime.now()
-
-            self.db.commit()
-        except SQLAlchemyError:
-            self.db.rollback()
-
-            raise Exception("Failed to delete routine")
+        routine.deleted_at = datetime.now()

--- a/app/dao/routine_element_dao.py
+++ b/app/dao/routine_element_dao.py
@@ -119,7 +119,7 @@ class RoutineElementDAO(ProtectedBaseDAO):
 
         return routine_element
 
-    def update_routine_elements(
+    def _update_routine_elements(
         self,
         routine_id: int,
         routine_elements: list[RoutineElement],
@@ -164,7 +164,7 @@ class RoutineElementDAO(ProtectedBaseDAO):
 
         return self.get_routine_elements_by_routine_id(routine_id)
 
-    def create_routine_elements(
+    def _create_routine_elements(
         self,
         routine_id: int,
         routine_elements: list[RoutineItemBase],
@@ -186,7 +186,5 @@ class RoutineElementDAO(ProtectedBaseDAO):
         except SQLAlchemyError:
             self.db.rollback()
             raise Exception("Failed to create routine elements")
-        else:
-            self.db.commit()
 
         return elements

--- a/app/dao/routine_element_dao.py
+++ b/app/dao/routine_element_dao.py
@@ -1,4 +1,3 @@
-from sqlalchemy.exc import SQLAlchemyError
 from fastapi import HTTPException, status
 
 from app.dao.base import ProtectedBaseDAO
@@ -47,18 +46,11 @@ class RoutineElementDAO(ProtectedBaseDAO):
         order: int | None,
         duration_minutes: int | None,
     ):
-        try:
-            routine_element.title = title or routine_element.title
-            routine_element.order = order or routine_element.order
-            routine_element.duration_minutes = (
-                duration_minutes or routine_element.duration_minutes
-            )
-            self.db.flush()
-        except SQLAlchemyError:
-            self.db.rollback()
-            raise Exception("Failed to update routine element")
-        else:
-            self.db.commit()
+        routine_element.title = title or routine_element.title
+        routine_element.order = order or routine_element.order
+        routine_element.duration_minutes = (
+            duration_minutes or routine_element.duration_minutes
+        )
 
         return routine_element
 
@@ -80,14 +72,7 @@ class RoutineElementDAO(ProtectedBaseDAO):
         return routine_element_result
 
     def delete_routine_element(self, routine_element: RoutineElement) -> None:
-        try:
-            self.db.delete(routine_element)
-            self.db.flush()
-        except SQLAlchemyError:
-            self.db.rollback()
-            raise Exception("Failed to delete routine element")
-        else:
-            self.db.commit()
+        self.db.delete(routine_element)
 
     def delete_routine_element_by_id(self, routine_element_id: int) -> None:
         routine_element = self.get_routine_element_by_id(routine_element_id)
@@ -100,26 +85,19 @@ class RoutineElementDAO(ProtectedBaseDAO):
         order: int,
         duration_minutes: int,
     ) -> RoutineElement:
-        try:
-            routine_element = RoutineElement(
-                user_id=self.user_id,
-                routine_id=routine_id,
-                title=title,
-                order=order,
-                duration_minutes=duration_minutes,
-            )
+        routine_element = RoutineElement(
+            user_id=self.user_id,
+            routine_id=routine_id,
+            title=title,
+            order=order,
+            duration_minutes=duration_minutes,
+        )
 
-            self.db.add(routine_element)
-            self.db.flush()
-        except SQLAlchemyError:
-            self.db.rollback()
-            raise Exception("Failed to create routine element")
-        else:
-            self.db.commit()
+        self.db.add(routine_element)
 
         return routine_element
 
-    def _update_routine_elements(
+    def update_routine_elements(
         self,
         routine_id: int,
         routine_elements: list[RoutineElement],
@@ -164,7 +142,7 @@ class RoutineElementDAO(ProtectedBaseDAO):
 
         return self.get_routine_elements_by_routine_id(routine_id)
 
-    def _create_routine_elements(
+    def create_routine_elements(
         self,
         routine_id: int,
         routine_elements: list[RoutineItemBase],
@@ -180,11 +158,6 @@ class RoutineElementDAO(ProtectedBaseDAO):
             for index, item in enumerate(routine_elements)
         ]
 
-        try:
-            self.db.add_all(elements)
-            self.db.flush()
-        except SQLAlchemyError:
-            self.db.rollback()
-            raise Exception("Failed to create routine elements")
+        self.db.add_all(elements)
 
         return elements

--- a/app/dao/todo_dao.py
+++ b/app/dao/todo_dao.py
@@ -84,13 +84,7 @@ class TodoDAO(ProtectedBaseDAO):
             user_id=self.user_id,
         )
 
-        try:
-            self.db.add(todo)
-            self.db.commit()
-
-        except Exception:
-            self.db.rollback()
-            raise
+        self.db.add(todo)
 
         return todo
 

--- a/app/dao/todo_dao.py
+++ b/app/dao/todo_dao.py
@@ -1,0 +1,168 @@
+from fastapi import HTTPException, status
+from app.api.strings import TODO_DOES_NOT_EXIST_ERROR
+from app.models.models import Todo
+
+from .base import ProtectedBaseDAO
+
+
+class TodoDAO(ProtectedBaseDAO):
+    def get_todo_by_id(self, todo_id: int) -> Todo:
+        """
+        query = text(
+                SELECT * FROM todo
+                WHERE id = :todo_id AND user_id = :user_id
+            )
+
+        result = self.db.execute(
+            query,
+            {
+                "todo_id": todo_id,
+                "user_id": self.user_id,
+            },
+        )
+
+        todo = result.fetchone()
+        """
+
+        todo = (
+            self.db.query(Todo)
+            .filter(Todo.id == todo_id, Todo.user_id == self.user_id)
+            .first()
+        )
+
+        if not todo:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=TODO_DOES_NOT_EXIST_ERROR,
+            )
+
+        return todo
+
+    def create_todo(
+        self,
+        title: str,
+        content: str = None,
+    ) -> Todo:
+        # def sql() -> Todo:
+        #     query = text(
+        #         """
+        #             INSERT INTO todo (
+        #                 title, content, user_id,
+        #                 completed, created_at, updated_at
+        #                 )
+        #             VALUES (
+        #                 :title, :content, :user_id, 0,
+        #                 datetime('now'), datetime('now')
+        #                 )
+        #         """
+        #     )
+
+        #     values = {
+        #         "title": title,
+        #         "content": content,
+        #         "user_id": self.user_id,
+        #     }
+        #     try:
+        #         self.db.execute(query, values)
+        #         self.db.flush()
+
+        #     except Exception:
+        #         self.db.rollback()
+        #         raise Exception("Failed to create todo")
+        #     else:
+        #         self.db.commit()
+
+        #         todo_id = self.db.execute(
+        #             text("SELECT last_insert_rowid()")
+        #         ).scalar()
+
+        #         return self.get_todo_by_id(todo_id=todo_id)
+
+        todo = Todo(
+            title=title,
+            content=content,
+            user_id=self.user_id,
+        )
+
+        try:
+            self.db.add(todo)
+            self.db.commit()
+
+        except Exception:
+            self.db.rollback()
+            raise
+
+        return todo
+
+    def update_todo(
+        self, todo_id: int, title: str, content: str = None
+    ) -> Todo:
+        # def sql():
+        #     query = text(
+        #         """
+        #                 UPDATE todo
+        #                 SET title = :title, content = :content,
+        #                 updated_at = datetime('now')
+        #                 WHERE id = :todo_id
+        #             """
+        #     )
+
+        #     values = {
+        #         "todo_id": todo_id,
+        #         "title": title,
+        #         "content": content,
+        #     }
+
+        #     self.db.execute(query, values)
+        #     self.db.flush()
+
+        #     return self.get_todo_by_id(todo_id=todo_id)
+
+        todo = (
+            self.db.query(Todo)
+            .filter(Todo.id == todo_id, Todo.user_id == self.user_id)
+            .first()
+        )
+
+        if not todo:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=TODO_DOES_NOT_EXIST_ERROR,
+            )
+
+        todo.title = title
+        todo.content = content
+
+        return todo
+
+    def delete_todo(self, todo_id: int) -> None:
+        # def sql():
+        #     query = text(
+        #         """
+        #                 DELETE FROM todo
+        #                 WHERE id = :todo_id
+        #         """
+        #     )
+
+        #     values = {"todo_id": todo_id}
+
+        #     self.db.execute(query, values)
+        #     self.db.flush()
+
+        #     return None
+
+        todo = (
+            self.db.query(Todo)
+            .filter(Todo.id == todo_id, Todo.user_id == self.user_id)
+            .first()
+        )
+
+        if not todo:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=TODO_DOES_NOT_EXIST_ERROR,
+            )
+
+        self.db.delete(todo)
+
+        return None

--- a/app/dao/user_dao.py
+++ b/app/dao/user_dao.py
@@ -1,0 +1,45 @@
+from fastapi import HTTPException, status
+from werkzeug.security import check_password_hash
+
+from app.api.strings import (
+    INVALID_LOGIN_ERROR,
+    USERNAME_CANNOT_BE_CHANGED_ERROR,
+)
+from app.models.models import User
+from app.schemas.user import UserUpdateInput
+
+from .base import ProtectedBaseDAO
+
+
+class UserDAO(ProtectedBaseDAO):
+    def update_me(self, data: UserUpdateInput) -> User:
+        user = self.db.query(User).filter_by(id=self.user_id).first()
+        # SELECT * FROM user WHERE id = :user_id
+
+        if data.username != self.username:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=USERNAME_CANNOT_BE_CHANGED_ERROR,
+            )
+
+        if not check_password_hash(user.password, data.password):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=INVALID_LOGIN_ERROR,
+            )
+
+        if data.email:
+            user.email = data.email
+
+        if data.profile_image == "":
+            user.profile_image = None
+        elif data.profile_image:
+            user.profile_image = data.profile_image
+
+        if data.nickname:
+            user.nickname = data.nickname
+
+        # UPDATE user SET email = :email, profile_image = :profile_image,
+        # nickname = :nickname WHERE id = :user_id
+
+        return user

--- a/app/database/db.py
+++ b/app/database/db.py
@@ -1,5 +1,7 @@
+from contextlib import contextmanager
+from fastapi import Depends
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy.orm import sessionmaker, declarative_base, Session
 
 from app.core.config import SQLALCHEMY_DATABASE_URI
 
@@ -9,9 +11,22 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
 
-def get_db():
-    db = SessionLocal()
+def get_db() -> Session:
+    session = SessionLocal()
     try:
-        yield db
+        yield session
+    except Exception as e:
+        session.rollback()
+        raise e
     finally:
-        db.close()
+        session.close()
+
+
+@contextmanager
+def tx_manager(session: Session = Depends(get_db)) -> None:
+    try:
+        if not session.in_transaction():
+            session.begin()
+        yield
+    finally:
+        session.commit()

--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -3,10 +3,11 @@ from sqlalchemy.orm import Session
 
 from app.core.auth import get_current_user
 from app.database.db import get_db
+from app.models.models import User
 from .routine_repository import RoutineRepository
 
 
 def get_routine_repository(
-    db: Session = Depends(get_db), user: int = Depends(get_current_user)
+    db: Session = Depends(get_db), user: User = Depends(get_current_user)
 ):
-    return RoutineRepository(db=db, user_id=user.id)
+    return RoutineRepository(db=db, user=user)

--- a/app/repositories/base.py
+++ b/app/repositories/base.py
@@ -1,5 +1,7 @@
 from sqlalchemy.orm import Session
 
+from app.models.models import User
+
 
 class BaseRepository:
     def __init__(self, db: Session):
@@ -7,7 +9,8 @@ class BaseRepository:
 
 
 class ProtectedBaseRepository(BaseRepository):
-    def __init__(self, db: Session, user_id: int):
+    def __init__(self, db: Session, user: User):
         super().__init__(db)
 
-        self.user_id = user_id
+        self.user_id = user.id
+        self.username = user.username

--- a/app/repositories/routine_repository.py
+++ b/app/repositories/routine_repository.py
@@ -1,4 +1,5 @@
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.dao.routine_dao import RoutineDAO
 from app.dao.routine_element_dao import RoutineElementDAO
@@ -20,32 +21,49 @@ class RoutineRepository(ProtectedBaseRepository):
         self.routine_element_dao = RoutineElementDAO(db, user_id)
 
     def update_routine(self, routine: RoutineUpdateInput) -> Routine:
-        updated_routine = self.routine_dao.update_routine(
-            routine_id=routine.routine_id,
-            title=routine.title,
-            start_time_minutes=routine.start_time_minutes,
-            repeat_days=routine.repeat_days,
-        )
+        try:
+            updated_routine = self.routine_dao._update_routine(
+                routine_id=routine.routine_id,
+                title=routine.title,
+                start_time_minutes=routine.start_time_minutes,
+                repeat_days=routine.repeat_days,
+            )
 
-        self.routine_element_dao.update_routine_elements(
-            routine_id=routine.routine_id,
-            routine_elements=updated_routine.routine_elements or [],
-            updates_routine_elements=routine.routine_elements or [],
-        )
+            self.routine_element_dao._update_routine_elements(
+                routine_id=routine.routine_id,
+                routine_elements=updated_routine.routine_elements or [],
+                updates_routine_elements=routine.routine_elements or [],
+            )
+
+        except SQLAlchemyError:
+            self.db.rollback()
+            raise Exception("Failed to update routine")
+
+        else:
+            self.db.commit()
 
         return updated_routine
 
     def create_routine(self, routine: RoutineCreateInput) -> RoutineDetail:
-        new_routine = self.routine_dao.create_routine(
-            title=routine.title,
-            start_time_minutes=routine.start_time_minutes,
-            repeat_days=routine.repeat_days,
-        )
+        try:
+            new_routine = self.routine_dao._create_routine(
+                title=routine.title,
+                start_time_minutes=routine.start_time_minutes,
+                repeat_days=routine.repeat_days,
+            )
 
-        routine_elements = self.routine_element_dao.create_routine_elements(
-            routine_id=new_routine.id,
-            routine_elements=routine.routine_elements,
-        )
+            routine_elements = (
+                self.routine_element_dao._create_routine_elements(
+                    routine_id=new_routine.id,
+                    routine_elements=routine.routine_elements,
+                )
+            )
+        except SQLAlchemyError:
+            self.db.rollback()
+            raise Exception("Failed to create routine")
+
+        else:
+            self.db.commit()
 
         return RoutineDetail.from_routine(
             routine=new_routine, routine_elements=routine_elements

--- a/app/repositories/routine_repository.py
+++ b/app/repositories/routine_repository.py
@@ -1,9 +1,8 @@
 from sqlalchemy.orm import Session
-from sqlalchemy.exc import SQLAlchemyError
 
 from app.dao.routine_dao import RoutineDAO
 from app.dao.routine_element_dao import RoutineElementDAO
-from app.models.models import Routine
+from app.models.models import Routine, User
 from app.schemas.routine import (
     RoutineCreateInput,
     RoutineDetail,
@@ -14,56 +13,47 @@ from .base import ProtectedBaseRepository
 
 
 class RoutineRepository(ProtectedBaseRepository):
-    def __init__(self, db: Session, user_id: int):
-        super().__init__(db, user_id)
+    def __init__(self, db: Session, user: User):
+        super().__init__(db, user)
 
-        self.routine_dao = RoutineDAO(db, user_id)
-        self.routine_element_dao = RoutineElementDAO(db, user_id)
+        self.routine_dao = RoutineDAO(db=db, user=user)
+        self.routine_element_dao = RoutineElementDAO(db=db, user=user)
 
-    def update_routine(self, routine: RoutineUpdateInput) -> Routine:
-        try:
-            updated_routine = self.routine_dao._update_routine(
-                routine_id=routine.routine_id,
-                title=routine.title,
-                start_time_minutes=routine.start_time_minutes,
-                repeat_days=routine.repeat_days,
-            )
+    def update_routine(
+        self, routine_id: int, routine: RoutineUpdateInput
+    ) -> Routine:
+        updated_routine = self.routine_dao.update_routine(
+            routine_id=routine_id,
+            title=routine.title,
+            start_time_minutes=routine.start_time_minutes,
+            repeat_days=routine.repeat_days,
+        )
 
-            self.routine_element_dao._update_routine_elements(
-                routine_id=routine.routine_id,
-                routine_elements=updated_routine.routine_elements or [],
-                updates_routine_elements=routine.routine_elements or [],
-            )
+        self.routine_element_dao.update_routine_elements(
+            routine_id=routine_id,
+            routine_elements=updated_routine.routine_elements or [],
+            updates_routine_elements=routine.routine_elements or [],
+        )
 
-        except SQLAlchemyError:
-            self.db.rollback()
-            raise Exception("Failed to update routine")
-
-        else:
-            self.db.commit()
+        self.db.flush()
 
         return updated_routine
 
     def create_routine(self, routine: RoutineCreateInput) -> RoutineDetail:
-        try:
-            new_routine = self.routine_dao._create_routine(
-                title=routine.title,
-                start_time_minutes=routine.start_time_minutes,
-                repeat_days=routine.repeat_days,
-            )
+        new_routine = self.routine_dao.create_routine(
+            title=routine.title,
+            start_time_minutes=routine.start_time_minutes,
+            repeat_days=routine.repeat_days,
+        )
 
-            routine_elements = (
-                self.routine_element_dao._create_routine_elements(
-                    routine_id=new_routine.id,
-                    routine_elements=routine.routine_elements,
-                )
-            )
-        except SQLAlchemyError:
-            self.db.rollback()
-            raise Exception("Failed to create routine")
+        self.db.flush()
 
-        else:
-            self.db.commit()
+        routine_elements = self.routine_element_dao.create_routine_elements(
+            routine_id=new_routine.id,
+            routine_elements=routine.routine_elements,
+        )
+
+        self.db.flush()
 
         return RoutineDetail.from_routine(
             routine=new_routine, routine_elements=routine_elements

--- a/app/schemas/routine.py
+++ b/app/schemas/routine.py
@@ -72,8 +72,6 @@ class RoutineItemUpdate(RoutineItemBase):
 
 
 class RoutineUpdateInput(BaseModel):
-    routine_id: int
-
     title: str | None
     start_time_minutes: int | None
     repeat_days: List[int] | None

--- a/tests/api/endpoints/protected/routine/conftest.py
+++ b/tests/api/endpoints/protected/routine/conftest.py
@@ -28,7 +28,6 @@ def routine_data() -> RoutineCreateInput:
 @pytest.fixture()
 def update_routine_only_routine_data() -> RoutineUpdateInput:
     return RoutineUpdateInput(
-        routine_id=1,
         title="점심 루틴",
         start_time_minutes=720,
         repeat_days=[1, 2, 3],
@@ -38,7 +37,6 @@ def update_routine_only_routine_data() -> RoutineUpdateInput:
 @pytest.fixture()
 def update_routine_empty_routine_elements() -> RoutineUpdateInput:
     return RoutineUpdateInput(
-        routine_id=1,
         routine_elements=[],
     )
 
@@ -46,7 +44,6 @@ def update_routine_empty_routine_elements() -> RoutineUpdateInput:
 @pytest.fixture()
 def update_routine_only_elements_data() -> RoutineUpdateInput:
     return RoutineUpdateInput(
-        routine_id=1,
         routine_elements=[
             RoutineItemUpdate(id=1, title="아침 물 마시기 업데이트", duration_minutes=5),
             RoutineItemUpdate(id=2, title="아침 운동하기 업데이트", duration_minutes=30),
@@ -59,7 +56,6 @@ def update_routine_only_elements_data() -> RoutineUpdateInput:
 @pytest.fixture
 def update_routine_all_data() -> RoutineUpdateInput:
     return RoutineUpdateInput(
-        routine_id=1,
         title="점심 루틴",
         start_time_minutes=120,
         repeat_days=[1, 2, 3],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,9 @@ from app.models.models import User
 from app.core.auth import generate_access_token
 from app.main import app as client_app
 
-engine = create_engine(os.environ.get("TSK_SQLALCHEMY_URL"))
+engine = create_engine(os.environ.get("TSK_SQLALCHEMY_URL"), echo=True)
 TestingSessionLocal = sessionmaker(
-    autocommit=False, autoflush=False, bind=engine
+    bind=engine, autocommit=False, autoflush=False
 )
 
 
@@ -32,15 +32,11 @@ def app():
 
 @pytest.fixture
 def session(app: FastAPI):
-    connection = engine.connect()
-    transaction = connection.begin()
-    session = Session(bind=connection)
+    session = TestingSessionLocal()
 
     yield session
 
     session.close()
-    transaction.rollback()
-    connection.close()
 
 
 @pytest.fixture()


### PR DESCRIPTION
Resolve #46 
# 작업 내용
- 기존 작성된 API를 DAO-Repo 방식으로 관리하도록 변경
- DB commit을 일괄적으로 API 레벨에서 진행하도록 변경
  - 이제 transaction 관리가 더 명확해지고, 기존에 잘못하고 있었던 부분도 수정함
- 테스트 환경과 프로덕션 환경의 DB session 설정을 동일하게 변경
  - 기존 테스트 환경에서만 begin을 열고 닫았었음. 