### PR TITLE
루틴 완료 여부 업데이트 API 추가

### DIFF
--- a/alembic/versions/0120742e9cc6_init.py
+++ b/alembic/versions/0120742e9cc6_init.py
@@ -1,8 +1,8 @@
 """Init
 
-Revision ID: 859a8f9b9afd
+Revision ID: 0120742e9cc6
 Revises: 
-Create Date: 2023-09-12 05:52:56.929502
+Create Date: 2023-11-08 06:43:20.717170
 
 """
 from typing import Sequence, Union
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = "859a8f9b9afd"
+revision: str = "0120742e9cc6"
 down_revision: Union[str, None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/app/dao/__init__.py
+++ b/app/dao/__init__.py
@@ -9,6 +9,7 @@ from .routine_element_dao import RoutineElementDAO
 from .todo_dao import TodoDAO
 from .auth_dao import AuthDAO
 from .user_dao import UserDAO
+from .routine_log_dao import RoutineLogDAO
 
 
 def get_routine_dao(
@@ -40,3 +41,9 @@ def get_user_dao(
     session: Session = Depends(get_db), user: User = Depends(get_current_user)
 ) -> UserDAO:
     return UserDAO(db=session, user=user)
+
+
+def get_routine_log_dao(
+    session: Session = Depends(get_db), user: User = Depends(get_current_user)
+) -> RoutineLogDAO:
+    return RoutineLogDAO(db=session, user=user)

--- a/app/dao/routine_log_dao.py
+++ b/app/dao/routine_log_dao.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+from typing import List
+
+from app.dao.base import ProtectedBaseDAO
+from app.models.models import RoutineLog
+
+
+class RoutineLogDAO(ProtectedBaseDAO):
+    def _is_timestamp_on_day(date: datetime, target_timestamp: datetime):
+        timestamp_date = target_timestamp.date()
+
+        return date == timestamp_date
+
+    def get_routine_log_by_date(
+        self, element_id: int, target_date: datetime
+    ) -> RoutineLog | None:
+        log = (
+            self.db.query(RoutineLog)
+            .filter(
+                RoutineLog.routine_element_id == element_id
+                and self._is_timestamp_on_day(
+                    target_date, RoutineLog.completed_at
+                )
+            )
+            .first()
+        )
+
+        return log
+
+    def update_logs_complete(self, completed: bool, item_ids: List[int]):
+        current_date = datetime.now().date()
+
+        for item_id in item_ids:
+            log = self.get_routine_log_by_date(item_id, current_date)
+
+            if completed:
+                self.add_log(item_id, log)
+            else:
+                self.remove_log(log)
+
+    def add_log(self, item_id: int, log: RoutineLog | None):
+        if log is None:
+            log = RoutineLog(
+                routine_element_id=item_id,
+            )
+
+            self.db.add(log)
+
+    def remove_log(self, log: RoutineLog | None):
+        if log is not None:
+            self.db.delete(log)

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,6 +1,14 @@
 from datetime import datetime
 from pydantic import validator
-from sqlalchemy import Column, Integer, String, Text, ForeignKey, TIMESTAMP
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Text,
+    ForeignKey,
+    TIMESTAMP,
+    func,
+)
 from sqlalchemy.orm import relationship
 
 from app.database.db import Base
@@ -16,7 +24,7 @@ class User(Base):
     grade = Column(Integer, nullable=False)
     profile_image = Column(String(100))
     nickname = Column(String(50))
-    created_at = Column(TIMESTAMP, default=datetime.utcnow)
+    created_at = Column(TIMESTAMP, default=func.now())
 
     todos = relationship("Todo", back_populates="user")
     habits = relationship("Habit", back_populates="user")
@@ -31,8 +39,8 @@ class Todo(Base):
     title = Column(String(100), nullable=False)
     content = Column(Text)
     completed = Column(Integer, default=0)
-    created_at = Column(TIMESTAMP, default=datetime.utcnow)
-    updated_at = Column(TIMESTAMP, default=datetime.utcnow)
+    created_at = Column(TIMESTAMP, default=func.now())
+    updated_at = Column(TIMESTAMP, default=func.now())
 
     user_id = Column(
         Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=False
@@ -50,10 +58,8 @@ class Habit(Base):
     active = Column(Integer, default=0)
     deleted_at = Column(TIMESTAMP)
 
-    created_at = Column(TIMESTAMP, default=datetime.utcnow)
-    updated_at = Column(
-        TIMESTAMP, default=datetime.utcnow, onupdate=datetime.utcnow
-    )
+    created_at = Column(TIMESTAMP, default=func.now())
+    updated_at = Column(TIMESTAMP, default=func.now(), onupdate=func.now())
 
     user_id = Column(
         Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=False
@@ -67,7 +73,7 @@ class HabitLog(Base):
 
     id = Column(Integer, primary_key=True)
 
-    completed_at = Column(TIMESTAMP)
+    completed_at = Column(TIMESTAMP, onupdate=func.now())
 
     habit_id = Column(
         Integer, ForeignKey("habit.id", ondelete="CASCADE"), nullable=False
@@ -85,10 +91,8 @@ class Routine(Base):
     repeat_days = Column(Text, nullable=False)
     deleted_at = Column(TIMESTAMP)
 
-    created_at = Column(TIMESTAMP, default=datetime.utcnow)
-    updated_at = Column(
-        TIMESTAMP, default=datetime.utcnow, onupdate=datetime.utcnow
-    )
+    created_at = Column(TIMESTAMP, default=func.now())
+    updated_at = Column(TIMESTAMP, default=func.now(), onupdate=func.now())
 
     user_id = Column(
         Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=False
@@ -162,10 +166,8 @@ class RoutineElement(Base):
     order = Column(Integer, nullable=False)
     duration_minutes = Column(Integer)
 
-    created_at = Column(TIMESTAMP, default=datetime.utcnow)
-    updated_at = Column(
-        TIMESTAMP, default=datetime.utcnow, onupdate=datetime.utcnow
-    )
+    created_at = Column(TIMESTAMP, default=func.now())
+    updated_at = Column(TIMESTAMP, default=func.now(), onupdate=func.now())
 
     deleted_at = Column(TIMESTAMP)
 
@@ -186,7 +188,7 @@ class RoutineLog(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
 
-    completed_at = Column(TIMESTAMP)
+    completed_at = Column(TIMESTAMP, default=func.now())
 
     routine_element_id = Column(
         Integer, ForeignKey("routine_element.id"), nullable=False

--- a/app/schemas/routine.py
+++ b/app/schemas/routine.py
@@ -77,3 +77,8 @@ class RoutineUpdateInput(BaseModel):
     repeat_days: List[int] | None
 
     routine_elements: List[RoutineItemUpdate] | None
+
+
+class RoutineItemCompleteUpdate(BaseModel):
+    completed: bool
+    item_ids: List[int]

--- a/tests/api/endpoints/protected/routine/conftest.py
+++ b/tests/api/endpoints/protected/routine/conftest.py
@@ -1,11 +1,13 @@
+from typing import List
 import pytest
 from sqlalchemy.orm import Session
-from app.models.models import Routine, RoutineElement, User
+from app.models.models import Routine, RoutineElement, RoutineLog, User
 
 from app.schemas.routine import (
     RoutineCreateInput,
     RoutineDetail,
     RoutineItem,
+    RoutineItemCompleteUpdate,
     RoutineItemUpdate,
     RoutineUpdateInput,
 )
@@ -25,7 +27,7 @@ def routine_data() -> RoutineCreateInput:
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def update_routine_only_routine_data() -> RoutineUpdateInput:
     return RoutineUpdateInput(
         title="점심 루틴",
@@ -34,14 +36,14 @@ def update_routine_only_routine_data() -> RoutineUpdateInput:
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def update_routine_empty_routine_elements() -> RoutineUpdateInput:
     return RoutineUpdateInput(
         routine_elements=[],
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def update_routine_only_elements_data() -> RoutineUpdateInput:
     return RoutineUpdateInput(
         routine_elements=[
@@ -115,3 +117,32 @@ def add_routine(
             for item in routine_elements
         ],
     )
+
+
+@pytest.fixture
+def add_routine_log__complete(
+    session: Session, add_routine: RoutineDetail
+) -> List[RoutineLog]:
+    routine_log = [
+        RoutineLog(
+            routine_element_id=1,
+        ),
+        RoutineLog(
+            routine_element_id=2,
+        ),
+    ]
+
+    session.add_all(routine_log)
+    session.commit()
+
+    return routine_log
+
+
+@pytest.fixture
+def update_log_data__complete() -> RoutineItemCompleteUpdate:
+    return RoutineItemCompleteUpdate(completed=True, item_ids=[1, 2, 3, 4])
+
+
+@pytest.fixture
+def update_log_data__incomplete() -> RoutineItemCompleteUpdate:
+    return RoutineItemCompleteUpdate(completed=False, item_ids=[1, 2, 3, 4])


### PR DESCRIPTION
Resolve #45
# 작업 내용
![스크린샷 2023-11-09 오전 2 36 39](https://github.com/upa-r-upa/taskie_backend/assets/56328777/187e8e59-5c94-4874-987e-551bca410b06)
- 루틴 내부 아이템의 완료 여부 업데이트 API를 추가했습니다.
# 상세
- 기존에 사용하고 있던 updated_at 등의 타임 관련한 기본 값 설정을 바꿨습니다. 서버 시간이 아니라 DB 시간으로 사용하도록 바꿨습니다.