### PR TITLE
투두 Order 업데이트 API 추가

### DIFF
--- a/alembic/versions/0120742e9cc6_init.py
+++ b/alembic/versions/0120742e9cc6_init.py
@@ -71,6 +71,7 @@ def upgrade() -> None:
         sa.Column("created_at", sa.TIMESTAMP(), nullable=True),
         sa.Column("updated_at", sa.TIMESTAMP(), nullable=True),
         sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("order", sa.Integer(), nullable=False),
         sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )

--- a/app/api/endpoints/todo.py
+++ b/app/api/endpoints/todo.py
@@ -6,7 +6,7 @@ from app.dao import get_todo_dao
 from app.dao.todo_dao import TodoDAO
 from app.database.db import tx_manager
 from app.schemas.response import Response
-from app.schemas.todo import TodoBase, TodoDetail
+from app.schemas.todo import TodoBase, TodoDetail, TodoUpdateInput
 
 router = APIRouter(
     prefix="/todo",
@@ -45,6 +45,7 @@ def create_todo(
         todo = dao.create_todo(
             title=data.title,
             content=data.content,
+            order=data.order,
         )
 
     return Response(
@@ -59,7 +60,7 @@ def create_todo(
 )
 def update_todo(
     todo_id: int,
-    data: TodoBase,
+    data: TodoUpdateInput,
     todo_dao: TodoDAO = Depends(get_todo_dao),
     tx_manager: contextmanager = Depends(tx_manager),
 ):

--- a/app/api/endpoints/todo.py
+++ b/app/api/endpoints/todo.py
@@ -6,7 +6,12 @@ from app.dao import get_todo_dao
 from app.dao.todo_dao import TodoDAO
 from app.database.db import tx_manager
 from app.schemas.response import Response
-from app.schemas.todo import TodoBase, TodoDetail, TodoUpdateInput
+from app.schemas.todo import (
+    TodoBase,
+    TodoDetail,
+    TodoOrderUpdateInput,
+    TodoUpdateInput,
+)
 
 router = APIRouter(
     prefix="/todo",
@@ -51,6 +56,24 @@ def create_todo(
     return Response(
         status_code=status.HTTP_201_CREATED, data=TodoDetail.from_orm(todo)
     )
+
+
+@router.put(
+    "/order",
+    response_model=None,
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def update_todo_list_order(
+    data: TodoOrderUpdateInput,
+    dao: TodoDAO = Depends(get_todo_dao),
+    tx_manager: contextmanager = Depends(tx_manager),
+):
+    with tx_manager:
+        dao.update_todo_list_order(
+            todo_list=data.todo_list,
+        )
+
+    return None
 
 
 @router.put(

--- a/app/dao/todo_dao.py
+++ b/app/dao/todo_dao.py
@@ -1,6 +1,8 @@
+from typing import List
 from fastapi import HTTPException, status
 from app.api.strings import TODO_DOES_NOT_EXIST_ERROR
 from app.models.models import Todo
+from app.schemas.todo import TodoOrderUpdate
 
 from .base import ProtectedBaseDAO
 
@@ -79,11 +81,7 @@ class TodoDAO(ProtectedBaseDAO):
 
         #     return self.get_todo_by_id(todo_id=todo_id)
 
-        todo = (
-            self.db.query(Todo)
-            .filter(Todo.id == todo_id, Todo.user_id == self.user_id)
-            .first()
-        )
+        todo = self.get_todo_by_id(todo_id=todo_id)
 
         if not todo:
             raise HTTPException(
@@ -112,11 +110,7 @@ class TodoDAO(ProtectedBaseDAO):
 
         #     return None
 
-        todo = (
-            self.db.query(Todo)
-            .filter(Todo.id == todo_id, Todo.user_id == self.user_id)
-            .first()
-        )
+        todo = self.get_todo_by_id(todo_id=todo_id)
 
         if not todo:
             raise HTTPException(
@@ -125,5 +119,14 @@ class TodoDAO(ProtectedBaseDAO):
             )
 
         self.db.delete(todo)
+
+        return None
+
+    def update_todo_list_order(self, todo_list: List[TodoOrderUpdate]) -> None:
+        for todo in todo_list:
+            # UPDATE todo SET order = :order WHERE id = :todo_id
+            target_todo = self.get_todo_by_id(todo_id=todo.id)
+
+            target_todo.order = todo.order
 
         return None

--- a/app/dao/todo_dao.py
+++ b/app/dao/todo_dao.py
@@ -41,46 +41,13 @@ class TodoDAO(ProtectedBaseDAO):
     def create_todo(
         self,
         title: str,
+        order: int,
         content: str = None,
     ) -> Todo:
-        # def sql() -> Todo:
-        #     query = text(
-        #         """
-        #             INSERT INTO todo (
-        #                 title, content, user_id,
-        #                 completed, created_at, updated_at
-        #                 )
-        #             VALUES (
-        #                 :title, :content, :user_id, 0,
-        #                 datetime('now'), datetime('now')
-        #                 )
-        #         """
-        #     )
-
-        #     values = {
-        #         "title": title,
-        #         "content": content,
-        #         "user_id": self.user_id,
-        #     }
-        #     try:
-        #         self.db.execute(query, values)
-        #         self.db.flush()
-
-        #     except Exception:
-        #         self.db.rollback()
-        #         raise Exception("Failed to create todo")
-        #     else:
-        #         self.db.commit()
-
-        #         todo_id = self.db.execute(
-        #             text("SELECT last_insert_rowid()")
-        #         ).scalar()
-
-        #         return self.get_todo_by_id(todo_id=todo_id)
-
         todo = Todo(
             title=title,
             content=content,
+            order=order,
             user_id=self.user_id,
         )
 

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -41,6 +41,7 @@ class Todo(Base):
     completed = Column(Integer, default=0)
     created_at = Column(TIMESTAMP, default=func.now())
     updated_at = Column(TIMESTAMP, default=func.now())
+    order = Column(Integer, nullable=False)
 
     user_id = Column(
         Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=False

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -48,6 +48,12 @@ class Todo(Base):
     )
     user = relationship("User", back_populates="todos")
 
+    @validator("title")
+    def title_must_not_be_empty(cls, v):
+        if not v:
+            raise ValueError("Title must not be empty")
+        return v
+
 
 class Habit(Base):
     __tablename__ = "habit"

--- a/app/schemas/todo.py
+++ b/app/schemas/todo.py
@@ -1,19 +1,19 @@
-from pydantic import BaseModel, validator
+from pydantic import BaseModel
 from datetime import datetime
 
 
 class TodoBase(BaseModel):
     title: str
+    order: int
     content: str = None
 
     class Config:
         orm_mode = True
 
-    @validator("title")
-    def title_must_not_be_empty(cls, v):
-        if not v:
-            raise ValueError("Title must not be empty")
-        return v
+
+class TodoUpdateInput(BaseModel):
+    title: str
+    content: str = None
 
 
 class TodoDetail(TodoBase):

--- a/app/schemas/todo.py
+++ b/app/schemas/todo.py
@@ -24,3 +24,12 @@ class TodoDetail(TodoBase):
 
     class Config:
         orm_mode = True
+
+
+class TodoOrderUpdate(BaseModel):
+    id: int
+    order: int
+
+
+class TodoOrderUpdateInput(BaseModel):
+    todo_list: list[TodoOrderUpdate]

--- a/tests/api/endpoints/protected/todo/conftest.py
+++ b/tests/api/endpoints/protected/todo/conftest.py
@@ -8,15 +8,15 @@ from app.schemas.todo import TodoBase
 
 @pytest.fixture
 def todo() -> TodoBase:
-    return TodoBase(title="Test title", content="Test content")
+    return TodoBase(title="Test title", content="Test content", order=1)
 
 
 @pytest.fixture
 def todo_list() -> List[TodoBase]:
     return List(
-        TodoBase(title="Test title 1", content="Test content 1"),
-        TodoBase(title="Test title 2", content="Test content 2"),
-        TodoBase(title="Test title 3", content="Test content 3"),
+        TodoBase(title="Test title 1", content="Test content 1", order=1),
+        TodoBase(title="Test title 2", content="Test content 2", order=2),
+        TodoBase(title="Test title 3", content="Test content 3", order=3),
     )
 
 
@@ -26,6 +26,7 @@ def add_todo(todo: TodoBase, session: Session, add_user: User) -> Todo:
         title=todo.title,
         content=todo.content,
         user_id=add_user.id,
+        order=todo.order,
     )
 
     session.add(todo_item)

--- a/tests/api/endpoints/protected/todo/conftest.py
+++ b/tests/api/endpoints/protected/todo/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.models.models import Todo, User
-from app.schemas.todo import TodoBase
+from app.schemas.todo import TodoBase, TodoOrderUpdateInput, TodoOrderUpdate
 
 
 @pytest.fixture
@@ -13,11 +13,11 @@ def todo() -> TodoBase:
 
 @pytest.fixture
 def todo_list() -> List[TodoBase]:
-    return List(
+    return [
         TodoBase(title="Test title 1", content="Test content 1", order=1),
         TodoBase(title="Test title 2", content="Test content 2", order=2),
         TodoBase(title="Test title 3", content="Test content 3", order=3),
-    )
+    ]
 
 
 @pytest.fixture
@@ -32,4 +32,37 @@ def add_todo(todo: TodoBase, session: Session, add_user: User) -> Todo:
     session.add(todo_item)
     session.commit()
 
-    yield todo_item
+    return todo_item
+
+
+@pytest.fixture
+def add_todo_list(
+    todo_list: List[TodoBase], session: Session, add_user: User
+) -> List[Todo]:
+    todo_list_items = []
+
+    for todo in todo_list:
+        todo_item = Todo(
+            title=todo.title,
+            content=todo.content,
+            user_id=add_user.id,
+            order=todo.order,
+        )
+
+        session.add(todo_item)
+        session.commit()
+
+        todo_list_items.append(todo_item)
+
+    return todo_list_items
+
+
+@pytest.fixture
+def todo_order_update_data() -> TodoOrderUpdateInput:
+    return TodoOrderUpdateInput(
+        todo_list=[
+            TodoOrderUpdate(id=1, order=3),
+            TodoOrderUpdate(id=2, order=1),
+            TodoOrderUpdate(id=3, order=2),
+        ]
+    )

--- a/tests/api/endpoints/protected/todo/test_todo.py
+++ b/tests/api/endpoints/protected/todo/test_todo.py
@@ -1,8 +1,9 @@
+from typing import List
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.models.models import Todo
-from app.schemas.todo import TodoDetail, TodoBase
+from app.schemas.todo import TodoDetail, TodoBase, TodoOrderUpdateInput
 
 
 def test_get_todo(client: TestClient, add_todo: Todo, access_token: str):
@@ -78,3 +79,41 @@ def test_delete_todo(
     assert response.status_code == 204
 
     assert session.query(Todo).filter(Todo.id == add_todo.id).first() is None
+
+
+def test_update_todo_list_order(
+    client: TestClient,
+    session: Session,
+    access_token: str,
+    add_todo_list: List[Todo],
+    todo_order_update_data: TodoOrderUpdateInput,
+):
+    response = client.put(
+        "/todo/order",
+        json=todo_order_update_data.dict(),
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 204
+
+    assert (
+        session.query(Todo)
+        .filter(Todo.id == add_todo_list[0].id)
+        .first()
+        .order
+        == 3
+    )
+    assert (
+        session.query(Todo)
+        .filter(Todo.id == add_todo_list[1].id)
+        .first()
+        .order
+        == 1
+    )
+    assert (
+        session.query(Todo)
+        .filter(Todo.id == add_todo_list[2].id)
+        .first()
+        .order
+        == 2
+    )


### PR DESCRIPTION
Resolve #79 
# 작업 내용
- 투두 order 업데이트 API를 추가했습니다.
- Todo model에 order를 추가했습니다.
- 기존 Todo create-update API에 order 개념을 추가했습니다.