### PR TITLE
불필요한 response_model의 status_code 제거

### DIFF
--- a/app/api/endpoints/auth.py
+++ b/app/api/endpoints/auth.py
@@ -16,7 +16,11 @@ from app.schemas.auth import (
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-@router.post("/signup", response_model=Response[SignupOutput], status_code=201)
+@router.post(
+    "/signup",
+    response_model=Response[SignupOutput],
+    status_code=status.HTTP_201_CREATED,
+)
 async def signup(
     data: SignupInput,
     auth_dao: AuthDAO = Depends(get_auth_dao),
@@ -27,12 +31,15 @@ async def signup(
 
     return Response(
         message="Signup success",
-        status_code=status.HTTP_201_CREATED,
         data=SignupOutput.from_orm(user),
     )
 
 
-@router.post("/login", response_model=Response[LoginOutput], status_code=200)
+@router.post(
+    "/login",
+    response_model=Response[LoginOutput],
+    status_code=status.HTTP_200_OK,
+)
 async def login(
     data: LoginInput,
     auth_dao: AuthDAO = Depends(get_auth_dao),
@@ -42,13 +49,14 @@ async def login(
         login_output = auth_dao.login(data.username, data.password)
 
     return Response(
-        status_code=status.HTTP_200_OK,
         data=login_output,
     )
 
 
 @router.post(
-    "/refresh", response_model=Response[RefreshOutput], status_code=200
+    "/refresh",
+    response_model=Response[RefreshOutput],
+    status_code=status.HTTP_200_OK,
 )
 async def refresh(
     data: RefreshInput, auth_dao: AuthDAO = Depends(get_auth_dao)
@@ -56,6 +64,5 @@ async def refresh(
     access_token = auth_dao.refresh(data.refresh_token)
 
     return Response(
-        status_code=status.HTTP_200_OK,
         data=RefreshOutput(access_token=access_token),
     )

--- a/app/api/endpoints/routines.py
+++ b/app/api/endpoints/routines.py
@@ -35,10 +35,7 @@ def create_routine(
     with tx_manager:
         routine = repository.create_routine(data)
 
-    return Response(
-        data=routine,
-        status_code=status.HTTP_201_CREATED,
-    )
+    return Response(data=routine)
 
 
 @router.get(
@@ -50,8 +47,7 @@ def get_routine(routine_id: int, dao: RoutineDAO = Depends(get_routine_dao)):
     routine = dao.get_routine_with_elements_by_id(routine_id)
 
     response = Response(
-        data=RoutineDetail.from_routine(routine, routine.routine_elements),
-        status_code=status.HTTP_200_OK,
+        data=RoutineDetail.from_routine(routine, routine.routine_elements)
     )
 
     return response
@@ -90,8 +86,7 @@ def update_routine(
         )
 
     return Response(
-        data=RoutineDetail.from_routine(routine, routine.routine_elements),
-        status_code=status.HTTP_200_OK,
+        data=RoutineDetail.from_routine(routine, routine.routine_elements)
     )
 
 

--- a/app/api/endpoints/todos.py
+++ b/app/api/endpoints/todos.py
@@ -35,9 +35,7 @@ def get_todo(
 ):
     todo = dao.get_todo_by_id(todo_id=todo_id)
 
-    return Response(
-        status_code=status.HTTP_200_OK, data=TodoDetail.from_orm(todo)
-    )
+    return Response(data=TodoDetail.from_orm(todo))
 
 
 @router.post(
@@ -57,9 +55,7 @@ def create_todo(
             order=data.order,
         )
 
-    return Response(
-        status_code=status.HTTP_201_CREATED, data=TodoDetail.from_orm(todo)
-    )
+    return Response(data=TodoDetail.from_orm(todo))
 
 
 @router.put(
@@ -98,9 +94,7 @@ def update_todo(
             content=data.content,
         )
 
-    return Response(
-        status_code=status.HTTP_200_OK, data=TodoDetail.from_orm(todo)
-    )
+    return Response(data=TodoDetail.from_orm(todo))
 
 
 @router.delete(
@@ -152,6 +146,5 @@ def get_todo_list(
     )
 
     return Response(
-        status_code=status.HTTP_200_OK,
         data=[TodoDetail.from_orm(todo) for todo in todo_list],
     )

--- a/app/api/endpoints/users.py
+++ b/app/api/endpoints/users.py
@@ -21,7 +21,6 @@ router = APIRouter(
 )
 def get_me(user: User = Depends(get_current_user)):
     return Response(
-        status_code=status.HTTP_200_OK,
         data=UserData.from_orm(user),
         message="User data retrieved successfully",
     )
@@ -39,6 +38,4 @@ def update_me(
     with tx_manager:
         user = user_dao.update_me(data)
 
-    return Response(
-        status_code=status.HTTP_200_OK, data=UserData.from_orm(user)
-    )
+    return Response(data=UserData.from_orm(user))

--- a/app/api/error_handlers.py
+++ b/app/api/error_handlers.py
@@ -1,5 +1,5 @@
 from typing import List
-from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 
@@ -8,23 +8,19 @@ from app.schemas.response import ErrorResponse, InnerErrorResponse
 
 def validation_exception_handler(app: FastAPI):
     @app.exception_handler(HTTPException)
-    async def custom_http_exception_handler(request: Request, exc: HTTPException):
+    async def custom_http_exception_handler(
+        request: Request, exc: HTTPException
+    ):
         return JSONResponse(
             status_code=exc.status_code,
-            content=ErrorResponse(
-                message=exc.detail,
-                status_code=exc.status_code,
-            ).dict(),
+            content=ErrorResponse(message=exc.detail).dict(),
         )
 
     @app.exception_handler(Exception)
     async def custom_exception_handler(request: Request, exc: Exception):
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content=ErrorResponse(
-                message="Internal Server Error",
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            ).dict(),
+            content=ErrorResponse(message="Internal Server Error").dict(),
         )
 
     def filtered_location_list(location: List[str]) -> List[str]:
@@ -46,10 +42,7 @@ def validation_exception_handler(app: FastAPI):
         ):
             return JSONResponse(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                content=ErrorResponse(
-                    message="Invalid JSON payload",
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                ).dict(),
+                content=ErrorResponse(message="Invalid JSON payload").dict(),
             )
 
         for detail in details:
@@ -63,8 +56,6 @@ def validation_exception_handler(app: FastAPI):
         return JSONResponse(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             content=ErrorResponse(
-                message="Validation Error",
-                errors=errors,
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                message="Validation Error", errors=errors
             ).dict(),
         )

--- a/app/schemas/response.py
+++ b/app/schemas/response.py
@@ -8,7 +8,6 @@ T = TypeVar("T")
 class Response(GenericModel, Generic[T]):
     data: Optional[T] = None
     message: str = ""
-    status_code: int
 
 
 class InnerErrorResponse(BaseModel):
@@ -18,5 +17,4 @@ class InnerErrorResponse(BaseModel):
 
 class ErrorResponse(BaseModel):
     message: str
-    status_code: int
     errors: List[InnerErrorResponse] | None = None


### PR DESCRIPTION
Resolve #86 

# 작업 내용
- 기존에 API Response model로 제공되던 status_code 항목이 사실상 기본적으로 return 하는 status_code와 다를 바 없어져서 중복인 것 같아 제거합니다. 